### PR TITLE
Make PublicKey and PrivateKey concrete types instead of traits

### DIFF
--- a/src/curve/curve25519.rs
+++ b/src/curve/curve25519.rs
@@ -131,6 +131,10 @@ impl KeyPair {
     pub fn public_key(&self) -> &[u8; PUBLIC_KEY_LENGTH] {
         &self.public_key
     }
+
+    pub fn private_key(&self) -> &[u8; PRIVATE_KEY_LENGTH] {
+        &self.private_key
+    }
 }
 
 impl From<[u8; PRIVATE_KEY_LENGTH]> for KeyPair {
@@ -139,21 +143,6 @@ impl From<[u8; PRIVATE_KEY_LENGTH]> for KeyPair {
             private_key,
             public_key: *PublicKey::from(&StaticSecret::from(private_key)).as_bytes(),
         }
-    }
-}
-
-impl From<KeyPair> for super::KeyPair {
-    fn from(kp: KeyPair) -> Self {
-        Self {
-            public_key: Box::new(super::DjbPublicKey(kp.public_key)),
-            private_key: Box::new(super::DjbPrivateKey(kp.private_key)),
-        }
-    }
-}
-
-impl From<super::DjbPrivateKey> for KeyPair {
-    fn from(djb_priv_key: super::DjbPrivateKey) -> Self {
-        Self::from(djb_priv_key.0)
     }
 }
 

--- a/src/ratchet/keys.rs
+++ b/src/ratchet/keys.rs
@@ -142,8 +142,8 @@ impl RootKey {
 
     pub fn create_chain(
         &self,
-        their_ratchet_key: &dyn curve::PublicKey,
-        our_ratchet_key: &dyn curve::PrivateKey,
+        their_ratchet_key: &curve::PublicKey,
+        our_ratchet_key: &curve::PrivateKey,
     ) -> Result<(RootKey, ChainKey)> {
         let shared_secret = curve::calculate_agreement(their_ratchet_key, our_ratchet_key)?;
         let derived_secret_bytes = self.kdf.derive_salted_secrets(

--- a/src/ratchet/params.rs
+++ b/src/ratchet/params.rs
@@ -6,9 +6,9 @@ pub struct AliceSignalProtocolParameters {
     our_base_key_pair: CurveKeyPair,
 
     their_identity_key: IdentityKey,
-    their_signed_pre_key: Box<dyn CurvePublicKey>,
-    their_one_time_pre_key: Option<Box<dyn CurvePublicKey>>,
-    their_ratchet_key: Box<dyn CurvePublicKey>,
+    their_signed_pre_key: CurvePublicKey,
+    their_one_time_pre_key: Option<CurvePublicKey>,
+    their_ratchet_key: CurvePublicKey,
 }
 
 impl AliceSignalProtocolParameters {
@@ -16,9 +16,9 @@ impl AliceSignalProtocolParameters {
         our_identity_key_pair: IdentityKeyPair,
         our_base_key_pair: CurveKeyPair,
         their_identity_key: IdentityKey,
-        their_signed_pre_key: Box<dyn CurvePublicKey>,
-        their_one_time_pre_key: Option<Box<dyn CurvePublicKey>>,
-        their_ratchet_key: Box<dyn CurvePublicKey>,
+        their_signed_pre_key: CurvePublicKey,
+        their_one_time_pre_key: Option<CurvePublicKey>,
+        their_ratchet_key: CurvePublicKey,
     ) -> Self {
         Self {
             our_identity_key_pair,
@@ -46,21 +46,18 @@ impl AliceSignalProtocolParameters {
     }
 
     #[inline]
-    pub fn their_signed_pre_key(&self) -> &dyn CurvePublicKey {
-        self.their_signed_pre_key.as_ref()
+    pub fn their_signed_pre_key(&self) -> &CurvePublicKey {
+        &self.their_signed_pre_key
     }
 
     #[inline]
-    pub fn their_one_time_pre_key(&self) -> Option<&dyn CurvePublicKey> {
-        match self.their_one_time_pre_key {
-            None => None,
-            Some(ref b) => Some(b.as_ref()),
-        }
+    pub fn their_one_time_pre_key(&self) -> Option<&CurvePublicKey> {
+        self.their_one_time_pre_key.as_ref()
     }
 
     #[inline]
-    pub fn their_ratchet_key(&self) -> &dyn CurvePublicKey {
-        self.their_ratchet_key.as_ref()
+    pub fn their_ratchet_key(&self) -> &CurvePublicKey {
+        &self.their_ratchet_key
     }
 }
 
@@ -71,7 +68,7 @@ pub struct BobSignalProtocolParameters {
     our_ratchet_key_pair: CurveKeyPair,
 
     their_identity_key: IdentityKey,
-    their_base_key: Box<dyn CurvePublicKey>,
+    their_base_key: CurvePublicKey,
 }
 
 impl BobSignalProtocolParameters {
@@ -80,9 +77,8 @@ impl BobSignalProtocolParameters {
         our_signed_pre_key_pair: CurveKeyPair,
         our_one_time_pre_key_pair: Option<CurveKeyPair>,
         our_ratchet_key_pair: CurveKeyPair,
-
         their_identity_key: IdentityKey,
-        their_base_key: Box<dyn CurvePublicKey>,
+        their_base_key: CurvePublicKey,
     ) -> Self {
         Self {
             our_identity_key_pair,
@@ -120,7 +116,7 @@ impl BobSignalProtocolParameters {
     }
 
     #[inline]
-    pub fn their_base_key(&self) -> &dyn CurvePublicKey {
-        self.their_base_key.as_ref()
+    pub fn their_base_key(&self) -> &CurvePublicKey {
+        &self.their_base_key
     }
 }


### PR DESCRIPTION
Using a trait for these meant we had to `Box` everything and probably took some overhead due to inlining being inhibited. But there was no corresponding advantage gained from this, because it's not like someone else was going to implement our traits and use RSA or something instead - any change in what key types are used (eg someday for post-quantum) will in any case require changes to this crate.

Somewhat unrelated question: why does decoding public key allow trailing garbage bytes? I checked and Java seems to have the same behavior, but C and SignalProtocolKit seem to require the key be exactly 1+32 bytes.