### PR TITLE
Run clippy in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,3 +22,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Clippy
+      run: cargo clippy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![allow(dead_code)]
 #![deny(unsafe_code)]
 


### PR DESCRIPTION
Using https://github.com/actions-rs/clippy-check means we have to build the crate (and all its deps) twice which seems wasteful. Instead I changed the crate to deny warnings (except dead code as there are still a few unused/unexported functions - I imagine those will either be exported or removed as the JNI work proceeds) which means clippy will also fail on any warnings which I think is better anyway so we stay clippy+warning free going forward.