### PR TITLE
Change benchmark to more accurately reflect performance

### DIFF
--- a/benches/session.rs
+++ b/benches/session.rs
@@ -4,7 +4,7 @@ use libsignal_protocol_rust::*;
 #[path = "../tests/support/mod.rs"]
 mod support;
 
-pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
+pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
     let (alice_session, bob_session) = support::initialize_sessions_v3()?;
     let alice_session_record = SessionRecord::new(alice_session);
     let bob_session_record = SessionRecord::new(bob_session);
@@ -20,13 +20,21 @@ pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalPro
 
     let message_to_decrypt = support::encrypt(&mut alice_store, &bob_address, "a short message")?;
 
-    c.bench_function("session encrypt", |b| {
+    c.bench_function("session decrypt first message", |b| {
         b.iter(|| {
-            let mut alice_store = alice_store.clone();
-            support::encrypt(&mut alice_store, &bob_address, "a short message").expect("success");
+            let mut bob_store = bob_store.clone();
+            support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt).expect("success");
         })
     });
 
+    let _ = support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)?;
+    let message_to_decrypt = support::encrypt(&mut alice_store, &bob_address, "a short message")?;
+
+    c.bench_function("session encrypt", |b| {
+        b.iter(|| {
+            support::encrypt(&mut alice_store, &bob_address, "a short message").expect("success");
+        })
+    });
     c.bench_function("session decrypt", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
@@ -37,10 +45,51 @@ pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalPro
     Ok(())
 }
 
+pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
+    let (alice_session, bob_session) = support::initialize_sessions_v3()?;
+    let alice_session_record = SessionRecord::new(alice_session);
+    let bob_session_record = SessionRecord::new(bob_session);
+
+    let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
+    let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);
+
+    let mut alice_store = support::test_in_memory_protocol_store();
+    let mut bob_store = support::test_in_memory_protocol_store();
+
+    alice_store.store_session(&bob_address, &alice_session_record)?;
+    bob_store.store_session(&alice_address, &bob_session_record)?;
+
+    c.bench_function("session encrypt+decrypt 1 way", |b| {
+        b.iter(|| {
+            let ctext = support::encrypt(&mut alice_store, &bob_address, "a short message")
+                .expect("success");
+            let _ptext = support::decrypt(&mut bob_store, &alice_address, &ctext).expect("success");
+        })
+    });
+
+    c.bench_function("session encrypt+decrypt ping pong", |b| {
+        b.iter(|| {
+            let ctext = support::encrypt(&mut alice_store, &bob_address, "a short message")
+                .expect("success");
+            let _ptext = support::decrypt(&mut bob_store, &alice_address, &ctext).expect("success");
+
+            let ctext = support::encrypt(&mut bob_store, &alice_address, "a short message")
+                .expect("success");
+            let _ptext = support::decrypt(&mut alice_store, &bob_address, &ctext).expect("success");
+        })
+    });
+
+    Ok(())
+}
+
+pub fn session_encrypt(mut c: &mut Criterion) {
+    session_encrypt_result(&mut c).expect("success");
+}
+
 pub fn session_encrypt_decrypt(mut c: &mut Criterion) {
     session_encrypt_decrypt_result(&mut c).expect("success");
 }
 
-criterion_group!(benches, session_encrypt_decrypt);
+criterion_group!(benches, session_encrypt, session_encrypt_decrypt);
 
 criterion_main!(benches);


### PR DESCRIPTION
I had been perplexed by the seemingly 10x overhead of decryption vs encryption in the benchmark results. Some of this happens "naturally" eg because bitsliced AES decryption is slower than encryption, but a 10x cost seemed way too high. Turned out the majority of the cost was because we were repeatedly decrypting as if it was the first message we had received from that peer, which causes a new X25519 key generation. [This is just due to how Criterion handles iterations, it seems to handle benchmarking stateful functions rather poorly so we have to clone the session state each time]

Changing the benchmark demonstrates that decrypting the first message is expensive but further messages in the same stream are just slightly (< 1.2x) slower than encrypting.