### PR TITLE
Improve the error types used for FFI errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,8 @@ pub enum SignalProtocolError {
     InvalidMessage(&'static str),
     InternalError(&'static str),
     FfiBindingError(String),
+    ApplicationCallbackThrewException(&'static str, Option<String>, String),
+    ApplicationCallbackReturnedIntegerError(&'static str, i32),
 }
 
 impl Error for SignalProtocolError {
@@ -178,6 +180,21 @@ impl fmt::Display for SignalProtocolError {
             SignalProtocolError::FfiBindingError(m) => {
                 write!(f, "error while invoking an ffi callback: {}", m)
             }
+            SignalProtocolError::ApplicationCallbackReturnedIntegerError(func, c) => {
+                write!(f, "application callback {} returned error code {}", func, c)
+            }
+            SignalProtocolError::ApplicationCallbackThrewException(func, t, m) => match t {
+                Some(t) => write!(
+                    f,
+                    "application callback {} threw exception {} with message {}",
+                    func, t, m
+                ),
+                None => write!(
+                    f,
+                    "application callback {} threw exception with message {}",
+                    func, m
+                ),
+            },
         }
     }
 }


### PR DESCRIPTION
For C ABI we can save the int error code that would be returned from an application callback written in Swift or TS without having to roundtrip through a string. For Java add a field to catch also the exception type that was thrown since that might prove useful for debugging etc.