### PR TITLE
Add a Transaction parameter which is passed back to storage callbacks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,8 @@ pub use {
     },
     state::{PreKeyBundle, PreKeyRecord, SessionRecord, SessionState, SignedPreKeyRecord},
     storage::{
-        Direction, IdentityKeyStore, InMemIdentityKeyStore, InMemPreKeyStore, InMemSenderKeyStore,
-        InMemSessionStore, InMemSignalProtocolStore, InMemSignedPreKeyStore, PreKeyStore,
-        ProtocolStore, SenderKeyStore, SessionStore, SignedPreKeyStore,
+        Context, Direction, IdentityKeyStore, InMemIdentityKeyStore, InMemPreKeyStore,
+        InMemSenderKeyStore, InMemSessionStore, InMemSignalProtocolStore, InMemSignedPreKeyStore,
+        PreKeyStore, ProtocolStore, SenderKeyStore, SessionStore, SignedPreKeyStore,
     },
 };

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,7 +14,7 @@ pub use {
         InMemSignalProtocolStore, InMemSignedPreKeyStore,
     },
     traits::{
-        Direction, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore, SessionStore,
-        SignedPreKeyStore,
+        Context, Direction, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
+        SessionStore, SignedPreKeyStore,
     },
 };

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -9,6 +9,8 @@ use crate::error::Result;
 use crate::state::{PreKeyId, PreKeyRecord, SessionRecord, SignedPreKeyId, SignedPreKeyRecord};
 use crate::{IdentityKey, IdentityKeyPair, ProtocolAddress, SenderKeyName, SenderKeyRecord};
 
+pub type Context = Option<*mut std::ffi::c_void>;
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Direction {
     Sending,
@@ -16,44 +18,69 @@ pub enum Direction {
 }
 
 pub trait IdentityKeyStore {
-    fn get_identity_key_pair(&self) -> Result<IdentityKeyPair>;
+    fn get_identity_key_pair(&self, ctx: Context) -> Result<IdentityKeyPair>;
 
-    fn get_local_registration_id(&self) -> Result<u32>;
+    fn get_local_registration_id(&self, ctx: Context) -> Result<u32>;
 
-    fn save_identity(&mut self, address: &ProtocolAddress, identity: &IdentityKey) -> Result<bool>;
+    fn save_identity(
+        &mut self,
+        address: &ProtocolAddress,
+        identity: &IdentityKey,
+        ctx: Context,
+    ) -> Result<bool>;
 
     fn is_trusted_identity(
         &self,
         address: &ProtocolAddress,
         identity: &IdentityKey,
         direction: Direction,
+        ctx: Context,
     ) -> Result<bool>;
 
-    fn get_identity(&self, address: &ProtocolAddress) -> Result<Option<IdentityKey>>;
+    fn get_identity(&self, address: &ProtocolAddress, ctx: Context) -> Result<Option<IdentityKey>>;
 }
 
 pub trait PreKeyStore {
-    fn get_pre_key(&self, prekey_id: PreKeyId) -> Result<PreKeyRecord>;
+    fn get_pre_key(&self, prekey_id: PreKeyId, ctx: Context) -> Result<PreKeyRecord>;
 
-    fn save_pre_key(&mut self, prekey_id: PreKeyId, record: &PreKeyRecord) -> Result<()>;
+    fn save_pre_key(
+        &mut self,
+        prekey_id: PreKeyId,
+        record: &PreKeyRecord,
+        ctx: Context,
+    ) -> Result<()>;
 
-    fn remove_pre_key(&mut self, prekey_id: PreKeyId) -> Result<()>;
+    fn remove_pre_key(&mut self, prekey_id: PreKeyId, ctx: Context) -> Result<()>;
 }
 
 pub trait SignedPreKeyStore {
-    fn get_signed_pre_key(&self, signed_prekey_id: SignedPreKeyId) -> Result<SignedPreKeyRecord>;
+    fn get_signed_pre_key(
+        &self,
+        signed_prekey_id: SignedPreKeyId,
+        ctx: Context,
+    ) -> Result<SignedPreKeyRecord>;
 
     fn save_signed_pre_key(
         &mut self,
         signed_prekey_id: SignedPreKeyId,
         record: &SignedPreKeyRecord,
+        ctx: Context,
     ) -> Result<()>;
 }
 
 pub trait SessionStore {
-    fn load_session(&self, address: &ProtocolAddress) -> Result<Option<SessionRecord>>;
+    fn load_session(
+        &self,
+        address: &ProtocolAddress,
+        ctx: Context,
+    ) -> Result<Option<SessionRecord>>;
 
-    fn store_session(&mut self, address: &ProtocolAddress, record: &SessionRecord) -> Result<()>;
+    fn store_session(
+        &mut self,
+        address: &ProtocolAddress,
+        record: &SessionRecord,
+        ctx: Context,
+    ) -> Result<()>;
 }
 
 pub trait SenderKeyStore {
@@ -61,11 +88,13 @@ pub trait SenderKeyStore {
         &mut self,
         sender_key_name: &SenderKeyName,
         record: &SenderKeyRecord,
+        ctx: Context,
     ) -> Result<()>;
 
     fn load_sender_key(
         &mut self,
         sender_key_name: &SenderKeyName,
+        ctx: Context,
     ) -> Result<Option<SenderKeyRecord>>;
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -27,6 +27,7 @@ pub fn encrypt(
         remote_address,
         &mut store.session_store,
         &mut store.identity_store,
+        None,
     )
 }
 
@@ -45,6 +46,7 @@ pub fn decrypt(
         &mut store.pre_key_store,
         &mut store.signed_pre_key_store,
         &mut csprng,
+        None,
     )
 }
 
@@ -58,7 +60,7 @@ pub fn create_pre_key_bundle<R: Rng + CryptoRng>(
 
     let signed_pre_key_public = signed_pre_key_pair.public_key.serialize();
     let signed_pre_key_signature = store
-        .get_identity_key_pair()?
+        .get_identity_key_pair(None)?
         .private_key()
         .calculate_signature(&signed_pre_key_public, &mut csprng)?;
 
@@ -67,17 +69,21 @@ pub fn create_pre_key_bundle<R: Rng + CryptoRng>(
     let signed_pre_key_id: u32 = csprng.gen();
 
     let pre_key_bundle = PreKeyBundle::new(
-        store.get_local_registration_id()?,
+        store.get_local_registration_id(None)?,
         device_id,
         Some(pre_key_id),
         Some(pre_key_pair.public_key),
         signed_pre_key_id,
         signed_pre_key_pair.public_key,
         signed_pre_key_signature.to_vec(),
-        *store.get_identity_key_pair()?.identity_key(),
+        *store.get_identity_key_pair(None)?.identity_key(),
     )?;
 
-    store.save_pre_key(pre_key_id, &PreKeyRecord::new(pre_key_id, &pre_key_pair))?;
+    store.save_pre_key(
+        pre_key_id,
+        &PreKeyRecord::new(pre_key_id, &pre_key_pair),
+        None,
+    )?;
 
     let timestamp = csprng.gen();
 
@@ -89,6 +95,7 @@ pub fn create_pre_key_bundle<R: Rng + CryptoRng>(
             &signed_pre_key_pair,
             &signed_pre_key_signature,
         ),
+        None,
     )?;
 
     Ok(pre_key_bundle)


### PR DESCRIPTION
This is needed on iOS which uses similar functionality so that all operations occur within a DB transaction.

We handle this within Rust as an Option<u64> with the assumption that the transaction memory address is just cast to an integer and then cast back in the FFI bridge code. Since we cannot know and do not want to know the actual type of the transaction.
